### PR TITLE
Exercise2

### DIFF
--- a/src/test/resources/application-context.xml
+++ b/src/test/resources/application-context.xml
@@ -9,6 +9,14 @@
         <property name="name" value="Ivan Ivanov"/>
         <property name="age" value="35"/>
         <property name="country" ref="country"/>
+        <property name="height" value="1.78"/>
+        <property name="isProgrammer" value="true"/>
+        <property name="contacts">
+            <list>
+                <value><![CDATA[asd@asd.ru]]></value>
+                <value><![CDATA[+7-234-456-67-89]]></value>
+            </list>
+        </property>
     </bean>
 
     <bean id="country" class="com.luxoft.springioc.lab2.model.Country">

--- a/src/test/resources/application-context.xml
+++ b/src/test/resources/application-context.xml
@@ -5,10 +5,9 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-    <bean id="person" class="com.luxoft.springioc.lab2.model.UsualPerson">
+    <bean id="person" class="com.luxoft.springioc.lab2.model.UsualPerson" autowire="byName">
         <property name="name" value="Ivan Ivanov"/>
         <property name="age" value="35"/>
-        <property name="country" ref="country"/>
         <property name="height" value="1.78"/>
         <property name="isProgrammer" value="true"/>
         <property name="contacts">


### PR DESCRIPTION
Answers to questions and additional information about issues:

Part 3
Ways to specify references to other classes
1. specify a reference to necessary bean
2. autowire

reference (advantages)
1. It's possible to place beans with the same class into application-context.xml file.
2. It's easier to read and check dependencies.

reference (disadvantages)
1. It's neccessary to configure application manually again and again.
2. It can significantly increase the volume of configuration

autowire (advantages)
1. Can cause configuration to keep itself up to date.
2. It can significantly reduce the volume of configuration

autowire (disadvantages)
1. Autowiring by type can work only if application context contains exactly one bean of given type.
2. It is harder to read and check dependencies.

Part 4
The difference is there is a prefix "classpath:" in ClassPathXmlApplicationContext's constructor parameter

Part5
1. Differences between SimpleAppTest and SpringTCFAppTest
- 	SimpleAppTest is configured by xml, SpringTCFAppTest is configured by annotations and xml
- 	Varible person is initialized by using instance of ApplicationContext in SimpleAppTest
- 	Varible person is initialized automatically by using @Autowire in SpringTCFAppTest
- 	Varible context is initialized  by passing config file as constructor parameter in SimpleAppTest
- 	Varible context is initialized  by passing config file as annotation parameter in SpringTCFAppTest

2. @RunWith annotation belongs to org.junit.runner library
3. @ContextConfiguration support following application context definitions:

- resource locations: @ContextConfiguration("/test-config.xml")
- component classes used to load the context: @ContextConfiguration(classes = TestConfig.class)
- declare ApplicationContextInitializer classes used to load the context: @ContextConfiguration(initializers = CustomContextIntializer.class)
- declare the ContextLoader strategy: @ContextConfiguration(loader = CustomContextLoader.class)
